### PR TITLE
Fix installation issue for Python 3+

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 django-weed
 ===========
 
-This project provides `Weed-FS <https://code.google.com/p/weed-fs/>`_ integration with Django by giving model field.
+This project provides `Weed-FS <https://code.google.com/p/weed-fs/>`_ integration with Django by giving model field. Works with Python 2 and Python 3 with Django 1.8+
 
 Dependencies
 ============
@@ -27,6 +27,15 @@ or
 How to use
 ==========
 
+Add `django-weed` specific constants to your `settings.py`
+
+.. code:: python
+
+    # django-weed
+    WEEDFS_MASTER_HOST = 'localhost'  # replace with your SeaweedFS master host
+    WEEDFS_MASTER_PORT = 9333  # replace with your SeaweedFS master port
+    ALLOW_NGINX_X_ACCEL_REDIRECT = True
+
 `django-weed` provides `WeedFSFileField` model field, so if you have regular `FileField` in your models:
 
 .. code:: python
@@ -45,7 +54,7 @@ you can easily convert this `FileField` to `WeedFSFileField`:
         name = models.CharField(_("Name"), max_length=255)
         content = WeedFSFileField(_("Content"))
 
-Note: there is no sense in upload_to keyword for Weed-FS as it uses flat file id structure.
+Note: there is no sense in `upload_to` keyword for Weed-FS as it uses flat file id structure.
 
 After that you can use content almost as before.
 

--- a/djweed/storage.py
+++ b/djweed/storage.py
@@ -26,7 +26,7 @@ class WeedFSStorage(Storage):
         self.master_port = master_port
         self.fs = WeedFS(master_host, master_port)
 
-    def get_available_name(self, name):
+    def get_available_name(self, name, **kwargs):
         return os.path.basename(name)
 
     def content(self, name):

--- a/djweed/urls.py
+++ b/djweed/urls.py
@@ -1,5 +1,6 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
+from .views import get_file
 
-urlpatterns = patterns('djweed.views',
-    url('^(?P<content_type_id>\d+)/(?P<object_id>\d+)/(?P<field_name>[\w\_]+)/(?P<file_name>[\w\.\_\-]*)$', 'get_file', name='weedfs_get_file'),
-) 
+urlpatterns = [
+    url('^(?P<content_type_id>\d+)/(?P<object_id>\d+)/(?P<field_name>[\w\_]+)/(?P<file_name>[\w\.\_\-]*)$', get_file, name='weedfs_get_file')
+]

--- a/djweed/version.py
+++ b/djweed/version.py
@@ -1,2 +1,3 @@
-VERSION = (0, 1, 2)
-__version__ = '.'.join(unicode(x) for x in VERSION)
+VERSION = (0, 2, 0)
+
+__version__ = "%s.%s.%s" % VERSION

--- a/djweed/views.py
+++ b/djweed/views.py
@@ -13,7 +13,7 @@ def get_file(request, content_type_id, object_id, field_name, file_name):
         field = getattr(obj, field_name)
     except (ObjectDoesNotExist, AttributeError):
         raise Http404
-    if settings.ALLOW_NGINX_X_ACCEL_REDIRECT:
+    if getattr(settings, 'ALLOW_NGINX_X_ACCEL_REDIRECT'):
         response = HttpResponse()
         response['X-Accel-Redirect'] = field.storage_url
     else:


### PR DESCRIPTION
I've tried to install `django-weed` with `pip` but it has failed with:

```
File "djweed/version.py", line 2, in <genexpr>
        __version__ = '.'.join(unicode(x) for x in VERSION)
    NameError: name 'unicode' is not defined
```

I'm using Python 3.6. Here is a fix that allows to install `django-weed` on Python 3+

Are you OK with such fix?