### PR TITLE
Renamed pyweed package and added compatibility for django 2.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ This project is built on top of `pyweed <https://github.com/utek/pyweed>`_ proje
 Thus dependencies are:
 
 * configured Weed-fS
-* pyweed module
+* pyseaweed module
 * django (tested only with 1.6 now, but should work with early releases as well)
 
 

--- a/djweed/db_fields.py
+++ b/djweed/db_fields.py
@@ -1,7 +1,7 @@
 from django.contrib.contenttypes.models import ContentType
 try:
     from django.core.urlresolvers import reverse
-except ImportError:  # Django 1.8
+except ImportError:  # Django 2.0
     from django.urls import reverse
 from django.db.models.fields.files import FieldFile, FileField
 from django.utils import six

--- a/djweed/db_fields.py
+++ b/djweed/db_fields.py
@@ -1,5 +1,8 @@
 from django.contrib.contenttypes.models import ContentType
-from django.core.urlresolvers import reverse
+try:
+    from django.core.urlresolvers import reverse
+except ImportError:  # Django 1.8
+    from django.urls import reverse
 from django.db.models.fields.files import FieldFile, FileField
 from django.utils import six
 

--- a/djweed/storage.py
+++ b/djweed/storage.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.core.files import File
 from django.core.files.storage import Storage
 
-from pyweed import WeedFS
+from pyseaweed import WeedFS
 
 # Python 2.x compatible
 try:

--- a/djweed/version.py
+++ b/djweed/version.py
@@ -1,3 +1,3 @@
-VERSION = (0, 2, 2)
+VERSION = (0, 2, 3)
 
 __version__ = "%s.%s.%s" % VERSION

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ META_DATA = {
 
     'packages': find_packages(),
 
-    'install_requires': ('django', 'pyweed>=0.3.3', ),
+    'install_requires': ('django', 'pyseaweed>=0.3.3', ),
 }
 
 if __name__ == "__main__":


### PR DESCRIPTION
1. Rename pyweed to pyseaweed based on https://github.com/utek/pyseaweed/commit/9ede653eb6c39d7797ce2d10e9c74b52330ad712
2. Added compatibility with Django >=1.8